### PR TITLE
Fix check for 'is commit already on remote'

### DIFF
--- a/tests/gitlab/test_gitlab_mr.py
+++ b/tests/gitlab/test_gitlab_mr.py
@@ -36,11 +36,11 @@ def test_create_ok(monkeypatch, requests_mocker: requests_mock.Mocker, caplog):
     session = GitlabUpdateSession(merge, run_cmd=run_cmd_ok, updates=[])
 
     # Set up the commands we expect it to run...
-    # git rev-parse
+    # git fetch
     procs.append(CompletedProcess([], returncode=0))
 
-    # branch contains
-    procs.append(CompletedProcess([], returncode=0, stdout=""))
+    # merge-base is-ancestor (1 means is not ancestor)
+    procs.append(CompletedProcess([], returncode=1))
 
     # push
     procs.append(CompletedProcess([], returncode=0))
@@ -123,11 +123,11 @@ def test_update_ok(monkeypatch, requests_mocker: requests_mock.Mocker, caplog):
     session = GitlabUpdateSession(merge, run_cmd=run_cmd_ok, updates=[])
 
     # Set up the commands we expect it to run...
-    # git rev-parse
+    # git fetch
     procs.append(CompletedProcess([], returncode=0))
 
-    # branch contains
-    procs.append(CompletedProcess([], returncode=0, stdout=""))
+    # merge-base is-ancestor (1 == 'is not ancestor')
+    procs.append(CompletedProcess([], returncode=1))
 
     # push
     procs.append(CompletedProcess([], returncode=0))

--- a/tests/gitlab/test_gitlab_promote.py
+++ b/tests/gitlab/test_gitlab_promote.py
@@ -73,14 +73,11 @@ def test_promote_already_present(
         ],
     )
 
-    # rev-parse: make it fail (don't have commit)
-    cmd_outputs.append(CompletedProcess([], 2))
-
     # fetch: succeeds
     cmd_outputs.append(CompletedProcess([], 0))
 
-    # branch contains: this one we simulate that it finds a branch
-    cmd_outputs.append(CompletedProcess([], 0, stdout="origin/mydest"))
+    # merge-base is-ancestor: 0 means it is already in dest branch
+    cmd_outputs.append(CompletedProcess([], 0))
 
     caplog.set_level(logging.INFO)
     session = GitlabPromoteSession(promote, run_cmd=run_cmd_ok)
@@ -132,11 +129,11 @@ def test_promote_create_mr(monkeypatch, requests_mocker: requests_mock.Mocker, c
         json={"web_url": "https://example.com/new-mr"},
     )
 
-    # rev-parse: ok
+    # fetch: ok
     cmd_outputs.append(CompletedProcess([], 0))
 
-    # branch contains: ok & no match
-    cmd_outputs.append(CompletedProcess([], 0))
+    # merge-base is-ancestor: no it isn't
+    cmd_outputs.append(CompletedProcess([], 1))
 
     # git push: ok
     cmd_outputs.append(CompletedProcess([], 0))


### PR DESCRIPTION
Make this explicitly fetch from the target URL and branch so we do not
rely on any particular git remotes or history already being present.

Fixes #41