### PR TITLE
Check for duplicate 'dir' in mirror config

### DIFF
--- a/mirror_tool/conf.py
+++ b/mirror_tool/conf.py
@@ -213,6 +213,14 @@ class Config:
     def validate(self) -> None:
         jsonschema.validate(self._raw, CONFIG_SCHEMA)
 
+        mirror_dirs = {mirror.dir for mirror in self.mirrors}
+        if len(mirror_dirs) != len(self.mirrors):
+            raise jsonschema.ValidationError(
+                message="Multiple mirrors defined using same dir",
+                path=["mirror"],
+                instance=self.mirrors,
+            )
+
     @classmethod
     def from_file(cls, filename=".mirror-tool.yaml") -> "Config":
         with open(filename, "rt") as f:


### PR DESCRIPTION
It doesn't make sense to have more than one mirror pointing at the same
dir, so treat that as invalid.

Fixes #34