### PR TITLE
Add a --dry-run option

### DIFF
--- a/mirror_tool/gitlab/promote.py
+++ b/mirror_tool/gitlab/promote.py
@@ -2,17 +2,18 @@ import logging
 
 from ..conf import GitlabPromote
 from ..jinja import jinja_args
-from .common import SHARED_LABEL, GitlabException, GitlabSession
+from .common import SHARED_LABEL, GitlabSession, RunCmd
 
 LOG = logging.getLogger("mirror-tool")
 
 
 class GitlabPromoteSession(GitlabSession):
-    def __init__(self, gitlab_promote: GitlabPromote, run_cmd):
-        super().__init__(gitlab_promote, run_cmd)
+    def __init__(
+        self, gitlab_promote: GitlabPromote, run_cmd: RunCmd, dry_run: bool = False
+    ):
+        super().__init__(gitlab_promote, run_cmd, dry_run)
         self.gitlab_promote = gitlab_promote
 
-        # TODO: can we put something useful in the jinja context?
         self.jinja_args = jinja_args(updates=[])
 
     def ensure_pushed_to_workbranch(self, revision):

--- a/mirror_tool/gitlab/update.py
+++ b/mirror_tool/gitlab/update.py
@@ -3,14 +3,20 @@ import logging
 from ..conf import GitlabMerge
 from ..git_info import UpdateInfo
 from ..jinja import jinja_args
-from .common import GitlabException, GitlabSession
+from .common import GitlabSession
 
 LOG = logging.getLogger("mirror-tool")
 
 
 class GitlabUpdateSession(GitlabSession):
-    def __init__(self, gitlab_merge: GitlabMerge, run_cmd, updates: list[UpdateInfo]):
-        super().__init__(gitlab_merge, run_cmd)
+    def __init__(
+        self,
+        gitlab_merge: GitlabMerge,
+        run_cmd,
+        updates: list[UpdateInfo],
+        dry_run: bool = False,
+    ):
+        super().__init__(gitlab_merge, run_cmd, dry_run)
         self.gitlab_merge = gitlab_merge
         self.updates = updates
         self.jinja_args = jinja_args(updates=self.updates)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mirror-tool"
-version = "0.7.0"
+version = "0.8.0"
 description = "A tool for managing git mirrors."
 readme = "README.md"
 homepage = "https://github.com/rohanpm/mirror-tool"

--- a/tests/gitlab/test_gitlab_dryrun.py
+++ b/tests/gitlab/test_gitlab_dryrun.py
@@ -1,0 +1,51 @@
+import logging
+
+import pytest
+import requests_mock
+
+from mirror_tool.conf import GitlabMerge
+from mirror_tool.gitlab import GitlabUpdateSession
+
+
+@pytest.mark.parametrize(
+    "mutator",
+    [
+        (lambda s: s.create_mr()),
+        (lambda s: s.update_mr({"iid": 12345})),
+        (lambda s: s.ensure_pushed_to("abc123", "dest")),
+        (lambda s: s.add_comment({"iid": 112233}, "my fake comment")),
+    ],
+    ids=["create", "update", "push", "comment"],
+)
+def test_dryrun_method(
+    monkeypatch, requests_mocker: requests_mock.Mocker, caplog, mutator
+):
+    """GitlabSession in dry-run mode doesn't do any HTTP requests."""
+
+    monkeypatch.setenv("GITLAB_MIRROR_TOKEN", "abc123-not-a-real-token")
+
+    merge = GitlabMerge(
+        api_v4_url="https://example.com/api",
+        project_id=123,
+        push_url="https://example.com/push",
+        src="some-src",
+        dest="some-dest",
+    )
+
+    def run_cmd_raise(*args, **kwargs):
+        # Should not try to run any commands.
+        raise AssertionError("unexpectedly ran a command: %s" % (args, kwargs))
+
+    caplog.set_level(logging.INFO)
+    session = GitlabUpdateSession(
+        merge, run_cmd=run_cmd_raise, updates=[], dry_run=True
+    )
+
+    # It should run without crashing...
+    mutator(session)
+
+    # ...but it didn't actually do anything.
+    assert requests_mocker.request_history == []
+
+    # And it should have mentioned dry run.
+    assert "DRY RUN" in caplog.text


### PR DESCRIPTION
Useful for testing config without actually doing pushes or MR updates.